### PR TITLE
add bops dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "through2": "^0.4.1"
   },
   "devDependencies": {
-    "tape": "~1.1.1",
+    "bops": "^1.0.0",
+    "concat-stream": "~1.2.0",
     "csv-spectrum": "~0.2.0",
-    "concat-stream": "~1.2.0"
+    "tape": "~1.1.1"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Currently bops is not in the package.json

it is getting resolved by default by npm3, but not by npm2
This make `npm test` sad (and me)

This also is blowing up smoke testing.

This PR adds bops to the package.json and now everyone can be happy!
